### PR TITLE
fix::소화기등록 실패 시 login-page으로의 redirect를 management-page로 수정

### DIFF
--- a/controllers/extinguisher.js
+++ b/controllers/extinguisher.js
@@ -26,7 +26,7 @@ exports.registerExtinguisher = async (req,res)=>{
     res.status(200).redirect(`/extinguisher/register?id=${result.dataValues.id}`);
     }catch(error){
         console.error(error);
-        return res.redirect(`/?error=${error}`);
+        return res.redirect(`/extinguisher/register?error=${error}`);
     }
 }
 
@@ -43,7 +43,7 @@ exports.management = async (req,res)=>{
       res.render('extinguishers/management',{extinguishers});
     }catch(err){
       console.error(err);
-      return res.redirect(`/?error=${error}`);
+      return res.redirect(`/extinguishers/management/?error=${error}`);
     }
   };
 


### PR DESCRIPTION
## fix::소화기등록 실패 시 login-page으로의 redirect를 management-page로 수정
- 수정전
redirect를 login-page로 해두어서 로그인된상태에서 로그인페이지로 넘어가는 현상 수정
- 수정후 
```
catch(error){
        console.error(error);
        return res.redirect(`/extinguisher/register?error=${error}`);
    }
```
