### PR TITLE
feat:: 라즈베리파이와 아두이노 Serial 통신

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Fire-Extinguisher-Management-System
 
-<img width="1120" alt="image" src="https://github.com/jjhwan-h/Fire-Extinguisher-Management-System/assets/92563695/b9bf7b0a-461a-434e-8b94-6a0221c9e6b6">
+<img width="1096" alt="image" src="https://github.com/jjhwan-h/Fire-Extinguisher-Management-System/assets/92563695/bdefe27d-7d25-444d-841f-15eb9730f966">
+
 

--- a/controllers/extinguishers.js
+++ b/controllers/extinguishers.js
@@ -51,23 +51,27 @@ exports.patchExtinguisher = async (req,res)=>{
   try{
     let extinguisher = req.body;
     console.log(extinguisher)
-    // /**소수점 자릿수 제한 */
-    //console.log(parseFloat(extinguisher.latitude).toFixed(9))
-    extinguisher.latitude = parseFloat(extinguisher.latitude).toFixed(9);
-    extinguisher.longitude = parseFloat(extinguisher.longitude).toFixed(9);
-    // /**제어문자 제거 */
-    extinguisher.desc.replace(/[\x00-\x1F\x7F]/g, "");
-    extinguisher.name.replace(/[\x00-\x1F\x7F]/g, "");
-    extinguisher.manufacturer.replace(/[\x00-\x1F\x7F]/g, "");
-    // /**소화기의 관리인 */
-    extinguisher.UserId=req.user.id;
-    
-    // const el = await Extinguisher.findOne({where:extinguisher['extinguisher-id'][0]});
-    // console.log(el);
-    const result = await Extinguisher.update(extinguisher,
-      {where:{id:extinguisher['extinguisher-id']}}).then(()=>{
-        return res.json({url:'/extinguishers?res=1'});
-      })
+    if(req.body.raspi){ //raspi으로부터의 온/습도, 기압정보 patch요청
+    }
+    else{ //클라이언트로부터의 명세, 이름, 제조업자, 제조일자 patch요청
+      // /**소수점 자릿수 제한 */
+      //console.log(parseFloat(extinguisher.latitude).toFixed(9))
+      extinguisher.latitude = parseFloat(extinguisher.latitude).toFixed(9);
+      extinguisher.longitude = parseFloat(extinguisher.longitude).toFixed(9);
+      // /**제어문자 제거 */
+      extinguisher.desc.replace(/[\x00-\x1F\x7F]/g, "");
+      extinguisher.name.replace(/[\x00-\x1F\x7F]/g, "");
+      extinguisher.manufacturer.replace(/[\x00-\x1F\x7F]/g, "");
+      // /**소화기의 관리인 */
+      extinguisher.UserId=req.user.id;
+      
+      // const el = await Extinguisher.findOne({where:extinguisher['extinguisher-id'][0]});
+      // console.log(el);
+      const result = await Extinguisher.update(extinguisher,
+        {where:{id:extinguisher['extinguisher-id']}}).then(()=>{
+          return res.json({url:'/extinguishers?res=1'});
+        })
+    }
     }catch(error){
         console.error(error);
         return res.redirect(`/registration?error=${error}`);

--- a/docs/NRF21L01.md
+++ b/docs/NRF21L01.md
@@ -1,0 +1,163 @@
+### 무선모듈
+
+<img width="296" alt="image" src="https://github.com/jjhwan-h/Fire-Extinguisher-Management-System/assets/92563695/9dc50220-a557-48be-9bce-dcc0f27be243">
+
+
+온습도, 압력 데이터 전송에 사용하는 모듈
+
+- 2.4GHz대역을 사용하는 RF통신모듈
+- NRF24L01P 모델은 현재(24.05) 제일 최신버전인 2.4Ghz무선 트랜시버 모듈
+- 외장형 안테나가  없는 모델은 NRF24L01P이고 외장 안테나가 추가된 모델은 NRF24L01 + PA +LNA 모델
+- 양방향 데이터 송수신 가능하지만 동시에 실시간 통신은 불가능한 Half duplex통신 모듈.
+
+> RF통신
+> 
+> 
+> RF통신 모듈은 Radio Frequency의 줄인말로 무선 주파수라는 뜻이다.
+> 무선주파수를 이용해 송신하고자 하는 정보를 전파로 변조한 후 전송을 하면 수신하는 모듈에서 수신된 전파를 복조하여 정보를 나타내는 원리
+> 1:1, 1:N, N:M통신 모두 가능
+> 
+
+- 스팩
+    
+    
+    | 항목 | 내용 |
+    | --- | --- |
+    | 칩 | 노르웨이 노르딕사 NRF24L01P 칩 |
+    | 통신거리 | 2dB의 안테나를 이용하여 1.1Km |
+    | 데이터 전송속도 | 250kbps |
+    | 부가기능 | Power Amplifier
+    Low Noise Amplifier |
+- 결선맵
+    
+    
+    | Arduino Uno R3
+    (ICSP) | NRF24L01P pin | 기타 |
+    | --- | --- | --- |
+    | +3.3v | +3.3v | 3.3v를 사용. 5v사용시 탈 수 있다. |
+    | GND | GND | ground in |
+    | D8 | CSN(=ss) | chip select in SS
+    (Slave select)핀
+    프로그램 소스 코딩 시  핀 변경가능 |
+    | D7 | CE | chip enable in 프로그램 소스 코딩시 핀 변경 가능 |
+    | MOSI(4) | MOSI | Mater Out Slave IN |
+    | SCK(3) | SCK | SPI clock in |
+    |  | IRQ |  |
+    | MISO(1) | MISO | Master In Slave Out |
+- 결선도
+
+<img width="477" alt="image" src="https://github.com/jjhwan-h/Fire-Extinguisher-Management-System/assets/92563695/55991b63-98fb-4937-9f31-e7495f88858f">
+
+-  위의 결선도는 오류가 있다. 아래의 결선도가 NRF24L01 + PA의 올바른 결선도 
+
+| MISO | IRQ |
+| --- | --- |
+| SCK | MOSI |
+| CE | CSN |
+| GND | VCC |
+
+
+- 1:1 통신 코드 & 회로도
+    
+    <img width="243" alt="image" src="https://github.com/jjhwan-h/Fire-Extinguisher-Management-System/assets/92563695/d1e5597b-eca1-4a7b-a268-3b079f933c39">
+
+    
+    - Rx
+    
+    ```cpp
+    #include <SPI.h> 
+    #include <nRF24L01.h>
+    #include <RF24.h>
+    RF24 radio(7, 8);     // SPI통신을 위한 (CE, CSN) 핀 선언
+    const byte address[6] = "00001"; // 송신기와 수신기가 동일한 값으로 주소 설정함(5자리)
+    void setup() {
+      Serial.begin(9600);
+      radio.begin();
+      radio.openReadingPipe(0, address);// 데이터를 받을 송신기 주소를 설정
+      radio.setPALevel(RF24_PA_MIN); // 송신거리에 따른, 전원공급 파워레벨 설정
+    //(최소) RF24_PA_MIN / RF24_PA_LOW / RF24_PA_HIGH / RF24_PA_MAX (최대) 설정가능
+    //송신이 약하다고 판단될 경우 nRF24모듈의 GND와 3.3V 단자에 전해콘덴서(10uF이상:+를3.3V연결)사용권장
+      radio.startListening();   // 모듈을 수신기(상태)로 설정
+    }
+    void loop() {
+      if (radio.available()) {
+        char text[32] = "";   // 데이터를 수신 받을 변수 설정
+        radio.read(&text, sizeof(text)); // 수신되는 데이터 길이만큼 읽어 저장
+        Serial.println(text);
+      }
+    }
+    ```
+    
+    - Tx
+    
+    ```cpp
+    #include <SPI.h>
+    #include <RF24.h>
+    RF24 radio(7, 8); // SPI통신을 위한 (CE, CSN) 핀 선언
+    const uint64_t address = 0xF1F1F0F0E0LL; // 송신기와 수신기가 동일한 값으로 주소 설정함(5자리)
+    void setup() {
+      radio.begin();
+      radio.setChannel(0x72);
+      radio.openWritingPipe(address); // 데이터를 보낼 수신 주소를 설정
+      radio.setPALevel(RF24_PA_HIGH); // 송신거리에 따른, 전원공급 파워레벨 설정
+    //(최소) RF24_PA_MIN / RF24_PA_LOW / RF24_PA_HIGH / RF24_PA_MAX (최대) 설정가능
+    //송신이 약하다고 판단될 경우 nRF24모듈의 GND와 3.3V 단자에 전해콘덴서(10uF이상:+를3.3V연결)사용권장
+    
+    //  radio.stopListening();  // 모듈을 송신기로 설정
+      radio.powerUp();
+    }
+    void loop() {
+      const char text[] = "(From) nRF24 Tx : HI"; // 송신할 문자
+    //  radio.write(&text, strlen(text)); // 위 문자를 문자 길이 만큼 송출함
+      radio.write(&text, sizeof(text)); // 위 문자를 문자 길이 만큼 송출함
+      delay(3000);
+    }
+    ```
+    
+- 구동사진
+    
+    
+- 1:n 통신 & 회로도
+    - 송신자 N, 수신자 1통신
+    - 최대 6개의 통신채널을 만들 수 있다.
+        
+        <img width="272" alt="image" src="https://github.com/jjhwan-h/Fire-Extinguisher-Management-System/assets/92563695/4412aeb2-78a3-471d-a298-d7310397ffcc">
+
+        
+    - 송신노드에서 수신노드로 수집한 값을 전송. 전송이 잘 완료되면  ACK신호를 전송.
+    - Tx입장에서는 통신 채널이 Rx하나이지만  RX입장에서는 Tx개수만큼(최대 6)의 통신채널을 가진다.
+    - 통신을 위한 주소값은 5byte
+    
+    - Rx
+        
+        ```cpp
+        
+        ```
+        
+    - Tx
+        
+        ```cpp
+        
+        ```
+        
+
+- 라이브러리
+    
+    https://github.com/nRF24/RF24
+    
+    [RF24-master.zip](https://prod-files-secure.s3.us-west-2.amazonaws.com/13092794-619e-423b-828c-ce5075dbf19e/e3cf52ec-137f-46f5-a3b6-3dfaa94e00cd/RF24-master.zip)
+    
+- 관련 링크
+    
+    [www.sparkfun.com](https://www.sparkfun.com/datasheets/Components/SMD/nRF24L01Pluss_Preliminary_Product_Specification_v1_0.pdf)
+    
+    [RF Communication with nRF24L01 and Raspberry Pi 4 - The Engineering Projects](https://www.theengineeringprojects.com/2022/11/rf-communication-with-nrf24l01-and-raspberry-pi-4.html)
+    
+    [아두이노 RF통신 nRF24L01 + 2.4GHz 모듈](https://m.blog.naver.com/eduino/222060455344)
+    
+    [[아두이노강좌]아두이노를 이용하여 통신하기-step3-NRF24L01모듈을 이용한 1:n통신](https://m.blog.naver.com/simjk98/221618424000)
+    
+    [【 아두이노모듈#19】 nRF24L01 :  2.4G RF 무선통신 하기! ( Arduino 통신 )](https://rasino.tistory.com/255)
+    
+
+아두이노(1) ⇒(RF통신)⇒ 아두이노(n) ⇒(시리얼통신)⇒ 라즈베리파이

--- a/raspi/serial.c
+++ b/raspi/serial.c
@@ -1,0 +1,75 @@
+// just that the Arduino IDE doesnt compile these files.
+#ifdef RaspberryPi
+
+//include system librarys
+#include <stdio.h> //for printf
+#include <stdint.h> //uint8_t definitions
+#include <stdlib.h> //for exit(int);
+#include <string.h> //for errno
+#include <errno.h> //error output
+
+//wiring Pi
+#include <wiringPi.h>
+#include <wiringSerial.h>
+
+// Find Serial device on Raspberry with ~ls /dev/tty*
+// ARDUINO_UNO "/dev/ttyACM0"
+// FTDI_PROGRAMMER "/dev/ttyUSB0"
+// HARDWARE_UART "/dev/ttyAMA0"
+char device[]= "/dev/ttyACM0";
+// filedescriptor
+int fd;
+unsigned long baud = 9600;
+unsigned long time=0;
+
+//prototypes
+int main(void);
+void loop(void);
+void setup(void);
+
+void setup(){
+
+  printf("%s \n", "Raspberry Startup!");
+  fflush(stdout);
+
+  //get filedescriptor
+  if ((fd = serialOpen (device, baud)) < 0){
+    fprintf (stderr, "Unable to open serial device: %s\n", strerror (errno)) ;
+    exit(1); //error
+  }
+
+  //setup GPIO in wiringPi mode
+  if (wiringPiSetup () == -1){
+    fprintf (stdout, "Unable to start wiringPi: %s\n", strerror (errno)) ;
+    exit(1); //error
+  }
+
+}
+
+void loop(){
+  // Pong every 3 seconds
+  if(millis()-time>=3000){
+    serialPuts (fd, "Pong!\n");
+    // you can also write data from 0-255
+    // 65 is in ASCII 'A'
+    serialPutchar (fd, 65);
+    time=millis();
+  }
+
+  // read signal
+  if(serialDataAvail (fd)){
+    char newChar = serialGetchar (fd);
+    printf("%c", newChar);
+    fflush(stdout);
+  }
+
+}
+
+// main function for normal c++ programs on Raspberry
+int main(){
+  setup();
+  while(1) loop();
+  return 0;
+}
+
+#endif //#ifdef RaspberryPi


### PR DESCRIPTION
## 아두이노-라즈베리파이 UART(Serial통신)

- 아두이노와 라즈베리파이연결은 USB케이블을 통해 쉽게 구현가능.
1. 아두이노 Idle설치
    
    ```python
    $sudo apt-get install arduino
    ```
    
2. 아두이노 패키지가 시리얼 포트에 액세스 할 수 있는 권한을 준다.
    
    ```python
    $sudo usermod -a -G tty [사용자명]
    $sudo usermod -a -G dialout [사용자명]
    ```
    
3. 라즈베리파이에서 아두이노의 Serial출력을 받아오는 코드
    
    ```python
    // just that the Arduino IDE doesnt compile these files.
    #ifdef RaspberryPi
    
    //include system librarys
    #include <stdio.h> //for printf
    #include <stdint.h> //uint8_t definitions
    #include <stdlib.h> //for exit(int);
    #include <string.h> //for errno
    #include <errno.h> //error output
    
    //wiring Pi
    #include <wiringPi.h>
    #include <wiringSerial.h>
    
    // Find Serial device on Raspberry with ~ls /dev/tty*
    // ARDUINO_UNO "/dev/ttyACM0"
    // FTDI_PROGRAMMER "/dev/ttyUSB0"
    // HARDWARE_UART "/dev/ttyAMA0"
    char device[]= "/dev/ttyACM0";
    // filedescriptor
    int fd;
    unsigned long baud = 9600;
    unsigned long time=0;
    
    //prototypes
    int main(void);
    void loop(void);
    void setup(void);
    
    void setup(){
    
      printf("%s \n", "Raspberry Startup!");
      fflush(stdout);
    
      //get filedescriptor
      if ((fd = serialOpen (device, baud)) < 0){
        fprintf (stderr, "Unable to open serial device: %s\n", strerror (errno)) ;
        exit(1); //error
      }
    
      //setup GPIO in wiringPi mode
      if (wiringPiSetup () == -1){
        fprintf (stdout, "Unable to start wiringPi: %s\n", strerror (errno)) ;
        exit(1); //error
      }
    
    }
    
    void loop(){
      // Pong every 3 seconds
      if(millis()-time>=3000){
        serialPuts (fd, "Pong!\n");
        // you can also write data from 0-255
        // 65 is in ASCII 'A'
        serialPutchar (fd, 65);
        time=millis();
      }
    
      // read signal
      if(serialDataAvail (fd)){
        char newChar = serialGetchar (fd);
        printf("%c", newChar);
        fflush(stdout);
      }
    
    }
    
    // main function for normal c++ programs on Raspberry
    int main(){
      setup();
      while(1) loop();
      return 0;
    }
    
    #endif //#ifdef RaspberryPi
    ```
    
- 만약 프로그램 구동 후 직접 종료하지 않을경우 터미널을 종료시켜도 프로그램은 계속 구동되기때문에 다시 연결 시 ttyACM0포트는 사용불가. `종료 시 ctrl+c로 확실히 종료해주도록 한다.`

<img width="452" alt="image" src="https://github.com/jjhwan-h/Fire-Extinguisher-Management-System/assets/92563695/9457e764-defd-499a-8433-14151bd7bc30">
