### PR TITLE
fix:: Rx에서 raspi로 값 전달포맷 수정

### DIFF
--- a/arduino/mRx.ino
+++ b/arduino/mRx.ino
@@ -1,15 +1,15 @@
+#include <ArduinoJson.h>
+
 #include <SPI.h> 
 #include <nRF24L01.h>
 #include <RF24.h>
-#include <ArduinoJson.h>
 
-#define PIPE_CNT 3
-
+#define raspiNUM 1 //1, 7, 13, 19
+#define PIPE_CNT 6
 
 RF24 radio(7, 8);     // SPI통신을 위한 (CE, CSN) 핀 선언
-const uint64_t address[PIPE_CNT]= {0xF1F1F0F0E0LL,0xF1F1F0F0E1LL}; // 송신기와 수신기가 동일한 값으로 주소 설정함(5자리,최대 6)
-int temp[PIPE_CNT]={0};
-int humi[PIPE_CNT]={0};
+const uint64_t address[PIPE_CNT]= {0xF1F1F0F0E0LL,0xF1F1F0F0E1LL,0xF1F1F0F0E2LL}; // 송신기와 수신기가 동일한 값으로 주소 설정함(5자리,최대 6)
+const int extinguisher[PIPE_CNT] ={22,23,24,25,26,27};
 void setup() {
   Serial.begin(9600);
   radio.begin();
@@ -26,28 +26,35 @@ void loop() {
   if (radio.available()) {
     char text[32] = "";   // 데이터를 수신 받을 변수 설정
     radio.read(&text, sizeof(text)); // 수신되는 데이터 길이만큼 읽어 저장
-
-    String splitStr[3];
-    String temp[3]; // 최대 3개로 분할한다고 가정
-    String humi[3];
+    
+    String splitStr[PIPE_CNT];
+    String temp[PIPE_CNT]; // 최대 3개로 분할한다고 가정
+    String humi[PIPE_CNT];
+    String num[PIPE_CNT];
     
     int index = 0;
     // strtok 함수를 사용하여 쉼표를 기준으로 문자열을 분할
     char* token = strtok(text, ",");
-    while (token != NULL && index < 10) {
+    while (token != NULL && index < PIPE_CNT) {
       // 분할된 토큰을 String 객체로 변환하여 배열에 저장
       splitStr[index] = String(token);
       index++;
       token = strtok(NULL, ",");
     }
-    temp[splitStr[2].toInt()]=splitStr[0];
-    humi[splitStr[2].toInt()]=splitStr[1];
-    
-    for (int i = 0; i < PIPE_CNT; i++) {
-    Serial.print(temp[i]);
-    Serial.println(humi[i]);
-  }
-    
+    temp[splitStr[2].toInt()]=splitStr[0]; //temp
+    humi[splitStr[2].toInt()]=splitStr[1]; //humi
+    num[splitStr[2].toInt()]=extinguisher[splitStr[2].toInt()]; //지역별 소화기+raspiNUM
+      Serial.print("s");
+      Serial.print(temp[splitStr[2].toInt()]+",");
+      Serial.print(humi[splitStr[2].toInt()]+",");
+      Serial.println(num[splitStr[2].toInt()]);
+//    StaticJsonDocument<200> json;
+//    String parsedJsonToString;
+//    json["humidity"]=humi[splitStr[2].toInt()];
+//    json["temperature"]=temp[splitStr[2].toInt()];
+//    json["num"]=num[splitStr[2].toInt()];
+//    serializeJson(json,parsedJsonToString);
+//    
     delay(5000);
   }
 }

--- a/arduino/mTx.ino
+++ b/arduino/mTx.ino
@@ -6,15 +6,16 @@
 
 #define DHTPIN 2      
 #define DHTTYPE DHT22 
-#define PIPE_CNT 3
-#define iNodeNum 0
+#define PIPE_CNT 6
+#define iNodeNum 1 //0~5 {22,23,24,25,26,27}
+
 
 DHT dht(DHTPIN, DHTTYPE);
 
 RF24 radio(7, 8); // SPI통신을 위한 (CE, CSN) 핀 선언
-const uint64_t address[PIPE_CNT]= {0xF1F1F0F0E0LL,0xF1F1F0F0E1LL}; // 송신기와 수신기가 동일한 값으로 주소 설정함(5자리,최대 6)
+const uint64_t address[PIPE_CNT]= {0,0xF1F1F0F0E0LL,0xF1F1F0F0E1LL}; // 송신기와 수신기가 동일한 값으로 주소 설정함(5자리,최대 6)
 void setup() {
-  Serial.begin(9600);개
+  Serial.begin(9600);
   radio.begin();
   radio.setChannel(0x72);
   radio.openWritingPipe(address[iNodeNum]); // 데이터를 보낼 수신 주소를 설정
@@ -29,59 +30,13 @@ void loop() {
   char send[32];
   String temp = String(dht.readTemperature(),2);
   String humi= String(dht.readHumidity(),2);
-  
+
   String text=temp+","+humi+","+iNodeNum;
   Serial.println(text);
 
   text.toCharArray(send,sizeof(send));
   
   bool success = radio.write(&send, sizeof(send));
-  
-  if(success){
-    Serial.println("Data sent successfully");
-  }
-  else{
-    Serial.println("Failed to send Data");
-  }
-  
-  delay(5000);
-}#include <SPI.h>
-#include <RF24.h>
-#include<nRF24L01.h>
-#include <DHT.h>
-
-
-#define DHTPIN 2      
-#define DHTTYPE DHT22 
-
-DHT dht(DHTPIN, DHTTYPE);
-
-RF24 radio(7, 8); // SPI통신을 위한 (CE, CSN) 핀 선언
-const uint64_t address= 0xF1F1F0F0E0LL; // 송신기와 수신기가 동일한 값으로 주소 설정함(5자리)
-void setup() {
-  Serial.begin(9600);
-  radio.begin();
-  radio.setChannel(0x72);
-  radio.openWritingPipe(address); // 데이터를 보낼 수신 주소를 설정
-  radio.setPALevel(RF24_PA_MIN); // 송신거리에 따른, 전원공급 파워레벨 설정
-//(최소) RF24_PA_MIN / RF24_PA_LOW / RF24_PA_HIGH / RF24_PA_MAX (최대) 설정가능
-//송신이 약하다고 판단될 경우 nRF24모듈의 GND와 3.3V 단자에 전해콘덴서(10uF이상:+를3.3V연결)사용권장
-  radio.powerUp();
-  radio.stopListening();
-  dht.begin();
-}
-void loop() {
-  char send[32];
-  String temp = String(dht.readTemperature(),2);
-  String humi= String(dht.readHumidity(),2);
-  
-  String text=temp+","+humi;
-  Serial.println(text);
-
-  text.toCharArray(send,sizeof(send));
-  
-  bool success = radio.write(&send, sizeof(send));
-  
   if(success){
     Serial.println("Data sent successfully");
   }


### PR DESCRIPTION
## fix:: Rx에서 raspi로 값 전달포맷 수정

```
temp[splitStr[2].toInt()]=splitStr[0]; //temp
    humi[splitStr[2].toInt()]=splitStr[1]; //humi
    num[splitStr[2].toInt()]=extinguisher[splitStr[2].toInt()]; //지역별 소화기+raspiNUM
      Serial.print("s");
      Serial.print(temp[splitStr[2].toInt()]+",");
      Serial.print(humi[splitStr[2].toInt()]+",");
      Serial.println(num[splitStr[2].toInt()]);
```
- 여러개의 소화기가 있기때문에 각 측정값의 시작과 끝을 알기위하여 
문자열의 시작은 "s" , 끝은 개행문자로 인식하게 포맷을 수정